### PR TITLE
Changed READme to add missing features testtool + fix unit test

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,14 @@ It's vital to recognize that updating the configuration file has three major imp
 
 >Note: please consult with the Teams App Test Tool documentation about the current limitations of using this framework when testing your Teams Copilot Starter project.
 
+#### Feature not available in Teams App Test tool
+
+The following features are not available in the Teams App Test tool
+
+1. The Teams App Test tool only works with bots. Tabs are not supported
+1. It is not supported to upload document. This will limit the PDF Skill or customization required manual upload of documents to be tested using the Test tool.
+1. The application/vnd.microsoft.card.oauth is not supported. This will make it not possible to start signin process using using the test tool as described in samples <https://github.com/microsoft/teams-ai/tree/main/js/samples/05.authentication>.
+
 ### Running Locally using Teams Toolkit Full Debugging Functionality
 
 To use Teams Toolkit to automate setup and debugging, please [continue below](#using-teams-toolkit-for-visual-studio-code).

--- a/__tests__/unit/bot/teamsAI.test.ts
+++ b/__tests__/unit/bot/teamsAI.test.ts
@@ -70,6 +70,11 @@ describe("TeamsAI", () => {
     );
     mockCompletePrompt.mockImplementation(() => Promise.resolve(mockedResult));
 
+    const mockedExtractJsonResponse = jest.spyOn(Utils, "extractJsonResponse");
+    mockedExtractJsonResponse.mockImplementation(
+      (inputString: string | undefined) => inputString ?? ""
+    );
+
     const result = await chatGPTSkill.run(input);
 
     expect(result).toBe(expectedContent);

--- a/__tests__/unit/skills/chatGPTSkill.test.ts
+++ b/__tests__/unit/skills/chatGPTSkill.test.ts
@@ -70,6 +70,11 @@ describe("ChatGPTSkill", () => {
     );
     mockCompletePrompt.mockImplementation(() => Promise.resolve(mockedResult));
 
+    const mockedExtractJsonResponse = jest.spyOn(Utils, "extractJsonResponse");
+    mockedExtractJsonResponse.mockImplementation(
+      (inputString: string | undefined) => inputString ?? ""
+    );
+
     const result = await chatGPTSkill.run(input);
 
     expect(result).toBe(expectedContent);


### PR DESCRIPTION
<!--
Please complete template before merging to main
-->

## Summary
Changed README.MD to add missing features testtool + fix unit tests

## Why
- Explain the missing features testtool 
- ensure unit tests work

## What
This pull request primarily focuses on improving the documentation and testing of the codebase. The most significant changes include updating the `README.md` file to provide more detailed information about the limitations of the Teams App Test tool, and adding a mock implementation of the `extractJsonResponse` method in two test suites.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R246-R253): Added a new section to detail the features that are not available in the Teams App Test tool, including limitations with bots, document upload, and application/vnd.microsoft.card.oauth. This provides clearer expectations for users of the tool.

Test improvements:

* [`__tests__/unit/bot/teamsAI.test.ts`](diffhunk://#diff-a0c641b2ff92a7d26773103c841d19ef4e090af61872e82359ff86342fcab7fdR73-R77): Added a mock implementation of the `extractJsonResponse` method from the `Utils` module. This allows for more controlled testing of the `run` method in the `TeamsAI` test suite.
* [`__tests__/unit/skills/chatGPTSkill.test.ts`](diffhunk://#diff-d344eabd711b6774f7e188811317c79fa62edd89f25b0b98019ebc4d2b668586R73-R77): Similarly, added a mock implementation of the `extractJsonResponse` method for the `ChatGPTSkill` test suite. This ensures consistent and predictable test results.

## Testing
<!--
Explain how the change was tested and any additional testing
-->


## Deployment
<!--
Explain any additional considers required during deployment e.g required existing infrastructure
-->
- [ ] Have you bumped the version for this PR following semantic versioning.

## Notes
<!--
Any additional information 
e.g. 
    Ground work required for up coming feature
-->