### PR TITLE
Sandervd/uploaddocument bugs

### DIFF
--- a/src/actions/chatWithDocument.ts
+++ b/src/actions/chatWithDocument.ts
@@ -104,7 +104,12 @@ export async function chatWithDocument(
   }
 
   try {
-    // Send an adaptive cards with the details
+    if (docs.length > 1) {
+      await context.sendActivity(
+        `You have uploaded ${docs.length} document(s) or website(s). These will be processed now.'`
+      );
+    }
+    // Send an adaptive cards with the details for each document
     for (const doc of docs) {
       const hashFromUri = crypto
         .createHash("sha256")
@@ -125,13 +130,6 @@ export async function chatWithDocument(
     logger.error(`Failed running skill: ${(error as Error).message}`);
     await context.sendActivity("I'm sorry, I could not process the document.");
     return AI.StopCommandName;
-  } finally {
-    // Delete the uploaded documents from the vectra index
-    // questionDocument.deleteExternalContent(
-    //   state.conversation.uploadedDocuments
-    // );
-    // state.conversation.uploadedDocuments = undefined;
-    // state.conversation.documentIds = [];
   }
   return "Provided document details.";
 }

--- a/src/actions/forgetDocuments.ts
+++ b/src/actions/forgetDocuments.ts
@@ -58,12 +58,6 @@ export async function forgetDocuments(
       );
     }
 
-    // Obtain the local index
-    const localIndex = vectraDS.index;
-
-    // Delete the local vectra index
-    localIndex.deleteIndex();
-
     // Log the uploaded documents that have been forgotten
     const documents = state.conversation.uploadedDocuments
       ?.map((doc) => doc.fileName)

--- a/src/actions/forgetDocuments.ts
+++ b/src/actions/forgetDocuments.ts
@@ -75,6 +75,7 @@ export async function forgetDocuments(
   }
 
   state.conversation.documentIds = [];
+  state.conversation.uploadedDocuments = undefined;
 
   if (state.conversation.definedWebUrl) {
     logger.info(

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -6,3 +6,4 @@ export { getCompanyDetails, getCompanyInfo } from "./fsi";
 export { webRetrieval } from "./webRetrieval";
 export { forgetDocuments } from "./forgetDocuments";
 export { getCompanyStockQuote } from "./getCompanyStockQuote";
+export { resetIndex } from "./resetIndex";

--- a/src/actions/resetIndex.ts
+++ b/src/actions/resetIndex.ts
@@ -1,0 +1,42 @@
+import { TurnContext } from "botbuilder";
+import { ApplicationTurnState } from "../models/aiTypes";
+import { container } from "tsyringe";
+import { logging } from "../telemetry/loggerManager";
+import { Env } from "../env";
+import { VectraDataSource } from "../dataSources/vectraDataSource";
+import { UserHelper } from "../helpers/userHelper";
+import { ActionsHelper } from "../helpers/actionsHelper";
+
+/**
+ * Resets the local Vectra index.
+ *
+ * @param {TurnContext} context - The turn context object.
+ * @param {ApplicationTurnState} state - The application turn state object.
+ * @returns {Promise<string>} A promise that resolves to a string indicating that the uploaded document has been forgotten.
+ */
+export async function resetIndex(
+  context: TurnContext,
+  state: ApplicationTurnState
+): Promise<string> {
+  const logger = logging.getLogger("bot.TeamsAI");
+  const env = container.resolve<Env>(Env);
+
+  // Get the user's information
+  const user = await UserHelper.updateUserInfo(context, state);
+
+  const vectraDS = new VectraDataSource({
+    name: env.data.WEBDATA_SOURCE_NAME,
+    embeddings: ActionsHelper.getEmbeddingsOptions(),
+    indexFolder: env.data.VECTRA_INDEX_PATH,
+  });
+
+  // Obtain the local index
+  const localIndex = vectraDS.index;
+
+  // Delete the local vectra index
+  localIndex.deleteIndex();
+  logger.info(
+    `The local Vectra index has been reset by ${user.userPrincipalName}.`
+  );
+  return "The local Vectra index has been reset.";
+}

--- a/src/bot/teamsAI.ts
+++ b/src/bot/teamsAI.ts
@@ -441,6 +441,9 @@ export class TeamsAI {
     this.app.message(
       BotMessageKeywords.newchat,
       async (context: TurnContext, state: ApplicationTurnState) => {
+        // forget documents from index
+        await forgetDocuments(context, state);
+        
         state.deleteConversationState();
         // change the prompt folder to the default
         state.conversation.promptFolder = this.env.data.DEFAULT_PROMPT_NAME;

--- a/src/bot/teamsAI.ts
+++ b/src/bot/teamsAI.ts
@@ -54,7 +54,8 @@ import {
   flaggedOutputAction,
   unknownAction,
   webRetrieval,
-  getCompanyStockQuote
+  getCompanyStockQuote,
+  resetIndex
 } from "../actions";
 import * as functionNames from "../functions/functionNames";
 import {
@@ -436,9 +437,9 @@ export class TeamsAI {
       }
     );
 
-    // Listen for /reset command and then delete the conversation state
+    // Listen for /newchat command and then delete the conversation state
     this.app.message(
-      BotMessageKeywords.reset,
+      BotMessageKeywords.newchat,
       async (context: TurnContext, state: ApplicationTurnState) => {
         state.deleteConversationState();
         // change the prompt folder to the default
@@ -448,8 +449,6 @@ export class TeamsAI {
         state.deleteUserState();
         CacheHelper.clearCurrentUser(state);
         CacheHelper.clearConversationHistory(state);
-        // Delete the local vectra index
-        this.LocalVectraIndex.deleteIndex();
         state.conversation.documentIds = [];
 
         await context.sendActivity(responses.reset());
@@ -460,21 +459,12 @@ export class TeamsAI {
       }
     );
 
-    // Listen for /forget command and then delete the document properties from state
+    // Listen for /resetIndex command and then delete the conversation state
     this.app.message(
-      BotMessageKeywords.forget,
+      BotMessageKeywords.resetIndex,
       async (context: TurnContext, state: ApplicationTurnState) => {
-        await context.sendActivity("Uploaded document has been forgotten.");
-        this.logger.info(
-          `${state.conversation.uploadedDocuments?.length} uploaded document have been forgotten.`
-        );
-        state.conversation.uploadedDocuments = undefined;
-        // Delete the local vectra index
-        this.LocalVectraIndex.deleteIndex();
-        state.conversation.documentIds = [];
-
-        // const appState = container.resolve<ApplicationState>(ApplicationState);
-        // appState.set(state, await UserHelper.getUserInfo(context, state));
+        const result = await resetIndex(context, state);
+        await context.sendActivity(result);
       }
     );
 
@@ -532,7 +522,7 @@ export class TeamsAI {
             ?.map((doc) => doc.fileName)
             .join(", ");
           await context.sendActivity(
-            `The current uploaded document(s) are ${documents}. Use "/forget" to forget the document(s).`
+            `The current uploaded document(s) are ${documents}. Use "forget documents" to forget the document(s).`
           );
         } else {
           await context.sendActivity(

--- a/src/helpers/actionsHelper.ts
+++ b/src/helpers/actionsHelper.ts
@@ -82,7 +82,10 @@ export class ActionsHelper {
         url: attachment.content.downloadUrl!,
         fileName: attachment.name!,
       }));
-      state.conversation.uploadedDocuments = attachments;
+      // add the uploaded documents to the state
+      state.conversation.uploadedDocuments =
+        state.conversation.uploadedDocuments ?? [];
+      state.conversation.uploadedDocuments?.push(...attachments);
     }
 
     // Log the uploaded files

--- a/src/models/aiTypes.ts
+++ b/src/models/aiTypes.ts
@@ -50,6 +50,7 @@ export interface TempState extends DefaultTempState {
   leaseId: string;
   startTime: number;
   typingTimer: NodeJS.Timeout | undefined;
+  hashFromUploadedDocument: string | undefined;
 }
 
 export type ApplicationTurnState = TurnState<

--- a/src/models/botMessageKeywords.ts
+++ b/src/models/botMessageKeywords.ts
@@ -5,6 +5,7 @@ export enum BotMessageKeywords {
   debug = "/debug",
   forget = "/forget",
   history = "/history",
-  reset = "/newchat",
+  newchat = "/newchat",
   welcome = "/welcome",
+  resetIndex = "/resetIndex",
 }

--- a/src/prompts/questionDocument/skprompt.txt
+++ b/src/prompts/questionDocument/skprompt.txt
@@ -7,6 +7,4 @@ The users are experts in AI and ethics, so they already know it is a language mo
 It should not be verbose in its answers, but does provide details and examples where it might help the explanation.
 The AI assistant must always return a response in the text form, ready to be read by the user. It should remove any JSON formatting before returning the response.
 
-Examples:
-User: What are the steps to bake a bread?
-AI: To bake a bread, you need to follow these steps:\n1. Mix water, flour, and yeast.\n2. Knead the dough.\n3. Let it rise.\n4. Bake it in the oven.
+The below can contain answers for multiple documents that are idenityfied by url:documentId. Give answer for each document.


### PR DESCRIPTION
<!--
Please complete template before merging to main
-->

## Summary
This PR solves 
Issue #1 
When document are uploaded in subsequent message and not forgotten, all the uploaded documents for the user will be answered. 
![image](https://github.com/microsoft/teams-copilot-starter/assets/13203032/5c2b95cd-3725-4484-9992-3dc2dba019ef)

Issue #2 
For each user only the documents of that user are being considered. This is done by going throught the list of uploadeddocuments and use search for each of them. By setting the document Id in the method renderData() only results from document with the correct document Id are returned.

Issue #3 
when more documents or more links are in a message, each are processed separate and give their own result.
![image](https://github.com/microsoft/teams-copilot-starter/assets/13203032/f8f42d65-369c-4ec9-bb84-c793bc951585)

In command /NewChat the document from the user are also removed
A new command /resetIndex is added to remove the index (for demo purposed or cleanup)

## Why
There were issues
#1
#2 
#3 
The needed to be solved to be able to work with mutiple document/websites and also with multiple users.

## What
This pull request includes significant changes to the chatbot's document processing, error handling, and state management. The most important changes include the addition of a SHA-256 hash to uniquely identify each document, the restructuring of the document processing flow to handle multiple documents, and the introduction of a new function to reset the local Vectra index.

Changes to document processing:

* [`src/actions/chatWithDocument.ts`](diffhunk://#diff-91a8f1471c7c1050ef1ac6a4d2016f0673bf604c7b37c445e446af3b0fb92884R17): Added a SHA-256 hash for each document URL to uniquely identify it. Restructured the document processing flow to handle multiple documents and provide feedback to the user. Improved error handling with a try-catch block. [[1]](diffhunk://#diff-91a8f1471c7c1050ef1ac6a4d2016f0673bf604c7b37c445e446af3b0fb92884R17) [[2]](diffhunk://#diff-91a8f1471c7c1050ef1ac6a4d2016f0673bf604c7b37c445e446af3b0fb92884L105-R134)
* [`src/actions/webRetrieval.ts`](diffhunk://#diff-27f43beb78b50de592cff4396b3e5a1ee059341362084db5cf531212e55a8326R22): Similar changes as in `chatWithDocument.ts` to handle multiple documents, add a SHA-256 hash for each document URL, and improve error handling. [[1]](diffhunk://#diff-27f43beb78b50de592cff4396b3e5a1ee059341362084db5cf531212e55a8326R22) [[2]](diffhunk://#diff-27f43beb78b50de592cff4396b3e5a1ee059341362084db5cf531212e55a8326L127-R156)

Changes to state management:

* [`src/actions/forgetDocuments.ts`](diffhunk://#diff-fea605baf8f636cdc1f9b8f04ebdb533af98a25563f9b82832fd4abbbd6f265cL61-L66): Removed code to delete the local Vectra index and added code to clear the uploaded documents from the conversation state. [[1]](diffhunk://#diff-fea605baf8f636cdc1f9b8f04ebdb533af98a25563f9b82832fd4abbbd6f265cL61-L66) [[2]](diffhunk://#diff-fea605baf8f636cdc1f9b8f04ebdb533af98a25563f9b82832fd4abbbd6f265cR72)
* [`src/bot/teamsAI.ts`](diffhunk://#diff-4743e163c329d878b28a204daf73cca5682bcfdce6b10634702cd6da74a64e65L439-R446): Changed the "/reset" command to "/newchat", and the "/forget" command to "/resetIndex". The "/resetIndex" command now uses the new `resetIndex` function. [[1]](diffhunk://#diff-4743e163c329d878b28a204daf73cca5682bcfdce6b10634702cd6da74a64e65L439-R446) [[2]](diffhunk://#diff-4743e163c329d878b28a204daf73cca5682bcfdce6b10634702cd6da74a64e65L451-L452) [[3]](diffhunk://#diff-4743e163c329d878b28a204daf73cca5682bcfdce6b10634702cd6da74a64e65L463-R470)
* [`src/helpers/actionsHelper.ts`](diffhunk://#diff-b524242e5d515ec7f822fb6b8baee206429d0fc1d69dd53f6caa3baa72d5841cL85-R88): Modified the handling of uploaded documents to append to the existing list in the state, rather than replacing it.
* [`src/models/aiTypes.ts`](diffhunk://#diff-2d7182ad33338ba4a5c57a34ab45a8a8e19d215b1d4954ea95c6571af7d6ed7fR53): Added a new `hashFromUploadedDocument` property to the `TempState` interface.

New function:

* [`src/actions/resetIndex.ts`](diffhunk://#diff-5a4cc594789876b10e9196c1bdbd73f4252489ccc4a4f55f1b5b1129eabd3499R1-R42): Added a new function to reset the local Vectra index. This function is now called by the "/resetIndex" command.
* [`src/actions/index.ts`](diffhunk://#diff-fd89ca9113dcbde2debb2aa77416f6123abd4f7ad338fad417c934b875e1e429R9): Exported the new `resetIndex` function.

Other changes:

* [`src/dataSources/vectraDataSource.ts`](diffhunk://#diff-449815024a7d86b57354fa12487fcda4a2ed8000b3225372aa9054736002862fR76-R83): Modified the `queryDocuments` function to filter results based on the document ID, which is derived from the SHA-256 hash. [[1]](diffhunk://#diff-449815024a7d86b57354fa12487fcda4a2ed8000b3225372aa9054736002862fR76-R83) [[2]](diffhunk://#diff-449815024a7d86b57354fa12487fcda4a2ed8000b3225372aa9054736002862fL85-R97)
* [`src/skills/byodSkill.ts`](diffhunk://#diff-c6a5ce7723a3b2d20956dfdd16155bb17e14f5e16d7ce750a1658288c13ba1c0R33-R54): Modified the `run` function to accept an optional `hashFromUri` parameter and store it in the temp state.
* [`src/prompts/questionDocument/skprompt.txt`](diffhunk://#diff-7dc02d61ae54d4555ccd29743ab9ba2af66fbf8d7829262ace3e5922de7d65afL10-R10): Updated the prompt text to reflect the changes in document processing.

## Testing
1. Upload two documents and ask to "summarize documents". This will give an answer for each document
2. Have 2 of more users upload document and have question. Each user should only get answers for their own documents
3. Upload a document and ask question. Then upload another document and answer question. In the latter it will give the answer on both documents


## Deployment
<!--
Explain any additional considers required during deployment e.g required existing infrastructure
-->
- [ ] Have you bumped the version for this PR following semantic versioning.

## Notes
<!--
Any additional information 
e.g. 
    Ground work required for up coming feature
-->