### PR TITLE
add complete url with anchor back in adpative card

### DIFF
--- a/src/actions/webRetrieval.ts
+++ b/src/actions/webRetrieval.ts
@@ -64,6 +64,7 @@ export async function webRetrieval(
   webSites.forEach((site) => {
     // Remove the anchor from the url as it refers to same site.
     site.fileName = site.fileName.split("#")[0];
+    site.completeUrl = site.fileName;
     if (
       !state.conversation.uploadedDocuments?.some(
         (doc) => doc.fileName === site.fileName
@@ -143,7 +144,7 @@ export async function webRetrieval(
       }
       const card = Utils.renderAdaptiveCard(byodAnswerCard, {
         docType: "the website",
-        filename: doc.fileName,
+        filename: doc.completeUrl,
         answer: response,
       });
       await context.sendActivity({ attachments: [card] });

--- a/src/actions/webRetrieval.ts
+++ b/src/actions/webRetrieval.ts
@@ -65,7 +65,6 @@ export async function webRetrieval(
     // Remove the anchor from the url as it refers to same site.
     site.completeUrl = site.fileName;
     site.fileName = site.fileName.split("#")[0];
-    site.completeUrl = site.fileName;
     if (
       !state.conversation.uploadedDocuments?.some(
         (doc) => doc.fileName === site.fileName

--- a/src/actions/webRetrieval.ts
+++ b/src/actions/webRetrieval.ts
@@ -63,6 +63,7 @@ export async function webRetrieval(
   // Add the web urls to the uploaded documents when they are not already in the list
   webSites.forEach((site) => {
     // Remove the anchor from the url as it refers to same site.
+    site.completeUrl = site.fileName;
     site.fileName = site.fileName.split("#")[0];
     site.completeUrl = site.fileName;
     if (

--- a/src/models/fileAttachment.ts
+++ b/src/models/fileAttachment.ts
@@ -4,4 +4,5 @@ export type FileAttachment = {
   fileName: string;
   blobName?: string | undefined;
   fileHash?: string | undefined;
+  completeUrl?: string | undefined;
 };


### PR DESCRIPTION
## Summary
we have trimmed the url with anchor and then while showing the response we show the trimmed URL instead of showing the original URL user provided. It can lead to inconsistency, when we return the response back we show the original URL and while storing in uploaded document we trim it and store. 

## Why
So that we give a consistent experience to user


## What
I added a field called `completeUrl` in FileAttachment.ts class. it is of optional type. 
while parsing the website links we get rid of anchors and push them in state. To solve above mentioned problem
I am add url with anchors to completeUrl field and later sending the same field as `fileName` to adaptive card.  

## Testing
Local testing is undergoing. 